### PR TITLE
Public data for DFUFirmware

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/Firmware/DFUFirmware.swift
+++ b/iOSDFULibrary/Classes/Implementation/Firmware/DFUFirmware.swift
@@ -58,6 +58,11 @@ import Foundation
 @objc public class DFUFirmware : NSObject, DFUStream {
     internal let stream: DFUStream?
     
+    /// The firmware data to be sent to the DFU target.
+    open var data: Data? {
+        return stream?.data
+    }
+    
     /// The name of the firmware file.
     @objc public let fileName: String?
     /// The URL to the firmware file.


### PR DESCRIPTION
# Purpose: 
I need have an access to DFUFirmware data. It's required for my Flutter version of DFU library.
@philips77  Do yo have any objections regarding adding computed value from DFUStream?