### PR TITLE
Add Expo library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Check platform folders for mode details about compatibility for each library.
 
 An unofficial library for both iOS and Android that is based on this library is available for React Native: [react-native-nordic-dfu](https://github.com/Salt-PepperEngineering/react-native-nordic-dfu)
 
+### Expo
+
+An unofficial Expo module for both iOS and Android that is based on this library is available: [expo-nordic-dfu](https://github.com/getquip/expo-nordic-dfu)
+
 ### Flutter
 
 A library for both iOS and Android that is based on this library is available for Flutter: 


### PR DESCRIPTION
We've started a new expo-module Nordic DFU library. It's modern - works with Expo SDK 52+, React Native Bridgeless, the iOS and Android files have been converted to Swift and Kotlin, and it has an Expo example app. Please give it a look and add the link if you deem it worthy!

https://github.com/getquip/expo-nordic-dfu